### PR TITLE
Refactor: Use `collectAsStateWithLifecycle` for UI state collection

### DIFF
--- a/feature/animedetail/src/main/java/com/nightfire/tonkotsu/animedetail/presentation/composable/AnimeDetailScreen.kt
+++ b/feature/animedetail/src/main/java/com/nightfire/tonkotsu/animedetail/presentation/composable/AnimeDetailScreen.kt
@@ -23,7 +23,6 @@ import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
-import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -33,6 +32,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.paging.compose.LazyPagingItems
 import androidx.paging.compose.collectAsLazyPagingItems
 import com.nightfire.tonkotsu.animedetail.presentation.AnimeDetailViewModel
@@ -61,11 +61,11 @@ fun AnimeDetailScreen(
     viewModel: AnimeDetailViewModel = hiltViewModel()
 ) {
 
-    val animeDetailState by viewModel.animeDetailState.collectAsState()
-    val animeCharactersState by viewModel.animeCharactersState.collectAsState()
-    val animeImagesState by viewModel.animeImagesState.collectAsState()
-    val animeVideosState by viewModel.animeVideosState.collectAsState()
-    val animeRecommendationState by viewModel.animeRecommendationsState.collectAsState()
+    val animeDetailState by viewModel.animeDetailState.collectAsStateWithLifecycle()
+    val animeCharactersState by viewModel.animeCharactersState.collectAsStateWithLifecycle()
+    val animeImagesState by viewModel.animeImagesState.collectAsStateWithLifecycle()
+    val animeVideosState by viewModel.animeVideosState.collectAsStateWithLifecycle()
+    val animeRecommendationState by viewModel.animeRecommendationsState.collectAsStateWithLifecycle()
 
     val animeEpisodes = viewModel.animeEpisodes.collectAsLazyPagingItems()
     val animeReviews = viewModel.animeReviews.collectAsLazyPagingItems()

--- a/feature/home/src/main/java/com/nightfire/tonkotsu/feature/home/presentation/composable/HomeScreen.kt
+++ b/feature/home/src/main/java/com/nightfire/tonkotsu/feature/home/presentation/composable/HomeScreen.kt
@@ -15,6 +15,7 @@ import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.nightfire.tonkotsu.core.common.UiState
 import com.nightfire.tonkotsu.core.domain.model.AnimeOverview
 import com.nightfire.tonkotsu.feature.home.presentation.HomeViewModel
@@ -28,9 +29,9 @@ fun HomeScreen(
     onNavigateToAnimeDetail: (Int) -> Unit,
     viewModel: HomeViewModel = hiltViewModel()
 ) {
-    val popularAnimeState by viewModel.popularAnimeState.collectAsState()
-    val topAiringAnimeState by viewModel.topAiringAnimeState.collectAsState()
-    val mostAnticipatedAnimeState by viewModel.mostAnticipatedAnimeState.collectAsState()
+    val popularAnimeState by viewModel.popularAnimeState.collectAsStateWithLifecycle()
+    val topAiringAnimeState by viewModel.topAiringAnimeState.collectAsStateWithLifecycle()
+    val mostAnticipatedAnimeState by viewModel.mostAnticipatedAnimeState.collectAsStateWithLifecycle()
 
     Scaffold(modifier = Modifier.systemBarsPadding()) { innerPadding ->
         HomeScreenContent(


### PR DESCRIPTION
This commit updates the `HomeScreen` and `AnimeDetailScreen` composables to use `collectAsStateWithLifecycle` instead of `collectAsState` when observing `StateFlow` from ViewModels.

**Key Changes:**

-   **`feature/home/src/main/java/com/nightfire/tonkotsu/feature/home/presentation/composable/HomeScreen.kt`:**
    -   Changed `popularAnimeState`, `topAiringAnimeState`, and `mostAnticipatedAnimeState` to use `viewModel.<stateFlow>.collectAsStateWithLifecycle()`.
-   **`feature/animedetail/src/main/java/com/nightfire/tonkotsu/animedetail/presentation/composable/AnimeDetailScreen.kt`:**
    -   Changed `animeDetailState`, `animeCharactersState`, `animeImagesState`, `animeVideosState`, and `animeRecommendationState` to use `viewModel.<stateFlow>.collectAsStateWithLifecycle()`.

Using `collectAsStateWithLifecycle` is the recommended approach for collecting flows in Compose UIs. It ensures that collection is lifecycle-aware, automatically starting and stopping collection based on the Composable's lifecycle, which helps prevent resource leaks and unnecessary background work.